### PR TITLE
stores listed, products in stores listed.

### DIFF
--- a/components/store/card.js
+++ b/components/store/card.js
@@ -1,28 +1,58 @@
 import Link from 'next/link'
+import { getProducts } from '../../data/products'
+import { useEffect, useState } from 'react'
+import { ProductCard } from '../product/card'
 
-export function StoreCard({ store, width= "is-half" }) {
-  return (
-    <div className={`column ${width}`}>
-      <div className="card">
-        <header className="card-header">
-          <p className="card-header-title">
-            {store.name}
-          </p>
-        </header>
-        <div className="card-content">
-          <p className="content">
-            Owner: {store.seller.first_name} {store.seller.last_name}
-          </p>
-          <div className="content">
-            {store.description}
-          </div>
+export function StoreCard({ store, seller }) {
+    const [productsInStore, setProductsInStore] = useState([])
+    const [isExpanded, setIsExpanded] = useState(false)
+
+    useEffect(() => {
+        getProducts(`store=${store.id}`).then(prodObjs => setProductsInStore(prodObjs))
+    }, [store.id])
+
+    const toggleExpand = () => {
+        setIsExpanded(!isExpanded)
+    }
+
+    return (
+        <div className={`column is-half`}>
+            <div className="card">
+                <header className="card-header">
+                    <p className="card-header-title">
+                        {store.name}
+                    </p>
+                </header>
+                <div className="card-content">
+                    <p className="content">
+                        Owner: {seller.first_name} {seller.last_name}
+                    </p>
+                    <div className="card-content">
+                        Description: {store.description}
+                    </div>
+                    <div className="card-content">
+                        Items in store: {store.product_count}
+                    </div>
+                </div>
+                <footer className="card-footer">
+                    <button className="card-footer-item" onClick={toggleExpand}>
+                        {isExpanded ? 'Hide Products' : 'View Products'}
+                    </button>
+                    <Link href={`stores/${store.id}`}>
+                        <a className="card-footer-item">View Store</a>
+                    </Link>
+                </footer>
+                {isExpanded && (
+                    <div className="product-list columns is-multiline ">
+                        {productsInStore.map(product => (
+                            <div  className="column is-one-quarter" key={product.id}>
+                                <ProductCard product={product} key={product.id} />
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
         </div>
-        <footer className="card-footer">
-          <Link href={`stores/${store.id}`}>
-            <a className="card-footer-item">View Store</a>
-          </Link>
-        </footer>
-      </div>
-    </div>
-  )
+    )
+    
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bangazon-client",
+  "name": "Bangazon-CLIENT-team-3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/pages/stores/index.js
+++ b/pages/stores/index.js
@@ -22,7 +22,7 @@ export default function Stores() {
       <div className="columns is-multiline">
       {
         stores.map(store => (
-          <StoreCard store={store} key={store.id} />
+          <StoreCard store={store} seller={store.seller} key={store.id} />
         ))
       }
       </div>


### PR DESCRIPTION
## Ticket:

36


## What Changed:

Added full logic for Stores to exist int database

added stores model, adjusted products model to take store_id instead of customer_id

deleted duplicate fixtures

changed fixtures to accomodate only existing products


**Testing Steps:**

pull down both api, and client repos.

***IN API SIDE, IMMEDIATLEY RESEED DATABASE WITH ./seed_data.sh****

open bangazon. you should be able to see all products list when clicking products tab.
\
open stores tab. you should see all stores, click view products, this should create a dropdown of all the items in that store. this grid still needs to be stylized better, but theres some learning to do with how next.js handles layouts or whatever is giong on there, that i've broken off into a separate ticket.
