### PR TITLE
Bug: Payments not appearing

### DIFF
--- a/data/payment-types.js
+++ b/data/payment-types.js
@@ -1,7 +1,7 @@
 import { fetchWithResponse, fetchWithoutResponse } from "./fetcher";
 
 export function getPaymentTypes() {
-  return fetchWithResponse('payment-types', {
+  return fetchWithResponse('paymenttypes', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`
     }
@@ -9,7 +9,7 @@ export function getPaymentTypes() {
 }
 
 export function addPaymentType(paymentType) {
-  return fetchWithResponse(`payment-types`, {
+  return fetchWithResponse(`paymenttypes`, {
     method: 'POST',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
@@ -20,7 +20,7 @@ export function addPaymentType(paymentType) {
 }
 
 export function deletePaymentType(id) {
-  return fetchWithoutResponse(`payment-types/${id}`, {
+  return fetchWithoutResponse(`paymenttypes/${id}`, {
     method: 'DELETE',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`


### PR DESCRIPTION
Simple adjustment to the url names in payment-types.js to match the url in postman, "paymenttypes". Card number does not appear because the payment types don't actually have card numbers! Easy check to run the website and see that the request is successful when /payments is loaded.

Related issue:
#Issue 47