### PR TITLE
Bug: Past orders not appearing

### DIFF
--- a/data/auth.js
+++ b/data/auth.js
@@ -21,7 +21,7 @@ export function register(user) {
 }
 
 export function getUserProfile() {
-  return fetchWithResponse('my-profile', {
+  return fetchWithResponse('profile', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
     }

--- a/data/payment-types.js
+++ b/data/payment-types.js
@@ -27,3 +27,15 @@ export function deletePaymentType(id) {
     }
   })
 }
+
+export function getSinglePaymentType(url) {
+  if (!url) return "No payment made"
+  const response = fetch(`${url}`, {
+    headers: {
+      Authorization: `Token ${localStorage.getItem('token')}`
+    }
+  })
+  return response
+}
+
+//note that the fetch for payments use the fetch url instead of pk so fetchWithResponse does not work here.

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -10,6 +10,23 @@ export default function Orders() {
   const [orders, setOrders] = useState([])
   const headers = ['Order Date', 'Total', 'Payment Method']
 
+  const fetchOrdersAndPaymentTypes = async () => {
+    const ordersData = await getOrders()
+    if (ordersData) {
+      const ordersWithPaymentTypes = await Promise.all(
+        ordersData.map(async (order) => ({
+          ...order,
+          paymentType: await fetchPaymentTypes(order.payment_type),
+          total: caculateTotal(order.lineitems)
+        }))
+      )
+      const validOrders = ordersWithPaymentTypes.filter(
+        order => order.paymentType !== "No payment made"
+      )
+      setOrders(validOrders)
+    }
+  }
+
   const fetchPaymentTypes = async (url) => {
       const response = await getSinglePaymentType(url);
       if (response === "No payment made") {
@@ -26,23 +43,6 @@ export default function Orders() {
   }
 
   useEffect(() => {
-    const fetchOrdersAndPaymentTypes = async () => {
-      const ordersData = await getOrders()
-      if (ordersData) {
-        const ordersWithPaymentTypes = await Promise.all(
-          ordersData.map(async (order) => ({
-            ...order,
-            paymentType: await fetchPaymentTypes(order.payment_type),
-            total: caculateTotal(order.lineitems)
-          }))
-        )
-        const validOrders = ordersWithPaymentTypes.filter(
-          order => order.paymentType !== "No payment made"
-        )
-        setOrders(validOrders)
-      }
-    }
-
     fetchOrdersAndPaymentTypes()
   }, [])
 

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -4,21 +4,19 @@ import Layout from '../components/layout'
 import Navbar from '../components/navbar'
 import Table from '../components/table'
 import { getOrders } from '../data/orders'
+import { getSinglePaymentType } from '../data/payment-types'
 
 export default function Orders() {
   const [orders, setOrders] = useState([])
   const headers = ['Order Date', 'Total', 'Payment Method']
 
   const fetchPaymentTypes = async (url) => {
-    if (!url) return "No payment made"
-
-    const response = await fetch(`${url}`, {
-      headers: {
-        Authorization: `Token ${localStorage.getItem('token')}`
+      const response = await getSinglePaymentType(url);
+      if (response === "No payment made") {
+        return response;
       }
-    })
-    const paymentReply = await response.json()
-    return paymentReply?.merchant_name
+      const paymentData = await response.json();
+      return paymentData.merchant_name;
   }
 
   const caculateTotal = (productArray) => {

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -36,7 +36,10 @@ export default function Orders() {
             total: caculateTotal(order.lineitems)
           }))
         )
-        setOrders(ordersWithPaymentTypes)
+        const validOrders = ordersWithPaymentTypes.filter(
+          order => order.paymentType !== "No payment made"
+        )
+        setOrders(validOrders)
       }
     }
 


### PR DESCRIPTION
This was honestly more of a feature with how little information the original fetch calls had. 

-Fixed the little profile bug while I was at it.
-Added a function to fetch the payment type
-Added a function to calculate cost
-Edited useEffect function to be async and allow the orders to be added onto to add those payment types and total

Test by running the site and navigating to "http://localhost:3000/my-orders" !