### PR TITLE
Bugfix/duplicate registration phone username email

### DIFF
--- a/data/auth.js
+++ b/data/auth.js
@@ -10,14 +10,14 @@ export function login(user) {
   })
 }
 
-export function register(user) {
-  return fetchWithResponse('register', {
+export async function register(user) {
+  return await fetchWithResponse('register', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify(user)
-  })
+  });
 }
 
 export function getUserProfile() {

--- a/data/fetcher.js
+++ b/data/fetcher.js
@@ -1,39 +1,33 @@
 const API_URL = 'http://localhost:8000';
 
-const checkErrorJson = async (response) => {
-  if (!response.ok) {
-    if (response.status === 401) {
-      window.location.href = "/login";
-    }
-    const errorData = await response.json();
-    throw new Error(errorData.message || 'Something went wrong');
+const checkError = (res) => {
+  if (!res.ok) {
+    throw Error(res.status);
   }
-  return response.json();
-};
+  return res
+}
 
-const handleError = (err) => {
- 
-if (err.status === 404) {
-    console.error('Resource not found:', err.message);
+const checkErrorJson = (res) => {
+  if (!res.ok) {
+    throw Error(res.status);
+  } else {
+    return res.json()
   }
-  throw err; // Re-throw the error for further handling
-};
+}
 
-export const fetchWithResponse = async (resource, options) => {
-  try {
-    const response = await fetch(`${API_URL}/${resource}`, options);
-    return await checkErrorJson(response);
-  } catch (error) {
-    handleError(error);
+const catchError = (err) => {
+  if (err.status === 401) {
+    window.location.href = "/login"
   }
-};
+  if (err.status === 404) {
+    throw Error(err.message);
+  }
+}
 
-export const fetchWithoutResponse = async (resource, options) => {
-  try {
-    const response = await fetch(`${API_URL}/${resource}`, options);
-    await checkErrorJson(response); // Check for errors but don't return the response
-    return true; // Or any other indicator of success
-  } catch (error) {
-    handleError(error);
-  }
-};
+export const fetchWithResponse = (resource, options) => fetch(${API_URL}/${resource}, options)
+  .then(checkErrorJson)
+  .catch(catchError)
+
+export const fetchWithoutResponse = (resource, options) => fetch(${API_URL}/${resource}, options)
+  .then(checkError)
+  .catch(catchError)

--- a/data/fetcher.js
+++ b/data/fetcher.js
@@ -1,4 +1,4 @@
-const API_URL = 'http://localhost:8000';
+const API_URL = 'http://localhost:8000'
 
 const checkError = (res) => {
   if (!res.ok) {
@@ -9,25 +9,28 @@ const checkError = (res) => {
 
 const checkErrorJson = (res) => {
   if (!res.ok) {
-    throw Error(res.status);
-  } else {
-    return res.json()
+    return res.json().then(error => {
+      // Create and throw a custom error object
+      throw { status: res.status, message: error.message || res.statusText };
+    });
   }
-}
+  return res.json();
+};
+
 
 const catchError = (err) => {
   if (err.status === 401) {
     window.location.href = "/login"
   }
-  if (err.status === 404) {
-    throw Error(err.message);
+  if (err.status === 404 || err.status === 400) {
+    throw err
   }
 }
 
-export const fetchWithResponse = (resource, options) => fetch(${API_URL}/${resource}, options)
+export const fetchWithResponse = (resource, options) => fetch(`${API_URL}/${resource}`, options)
   .then(checkErrorJson)
   .catch(catchError)
 
-export const fetchWithoutResponse = (resource, options) => fetch(${API_URL}/${resource}, options)
+export const fetchWithoutResponse = (resource, options) => fetch(`${API_URL}/${resource}`, options)
   .then(checkError)
   .catch(catchError)

--- a/data/fetcher.js
+++ b/data/fetcher.js
@@ -2,6 +2,9 @@ const API_URL = 'http://localhost:8000';
 
 const checkErrorJson = async (response) => {
   if (!response.ok) {
+    if (response.status === 401) {
+      window.location.href = "/login";
+    }
     const errorData = await response.json();
     throw new Error(errorData.message || 'Something went wrong');
   }
@@ -9,9 +12,8 @@ const checkErrorJson = async (response) => {
 };
 
 const handleError = (err) => {
-  if (err.status === 401) {
-    window.location.href = "/login";
-  } else if (err.status === 404) {
+ 
+if (err.status === 404) {
     console.error('Resource not found:', err.message);
   }
   throw err; // Re-throw the error for further handling

--- a/data/fetcher.js
+++ b/data/fetcher.js
@@ -5,17 +5,16 @@ const checkErrorJson = async (response) => {
     const errorData = await response.json();
     throw new Error(errorData.message || 'Something went wrong');
   }
-  return response.json(); // Ensure to return the parsed JSON
+  return response.json();
 };
 
-const catchError = (err) => {
-  if (err.message === '401') {
+const handleError = (err) => {
+  if (err.status === 401) {
     window.location.href = "/login";
-  } else if (err.message === '404') {
-    throw Error(err.message);
-  } else {
-    throw err; // Re-throw other errors so they can be handled by the caller
+  } else if (err.status === 404) {
+    console.error('Resource not found:', err.message);
   }
+  throw err; // Re-throw the error for further handling
 };
 
 export const fetchWithResponse = async (resource, options) => {
@@ -23,17 +22,16 @@ export const fetchWithResponse = async (resource, options) => {
     const response = await fetch(`${API_URL}/${resource}`, options);
     return await checkErrorJson(response);
   } catch (error) {
-    catchError(error);
-    throw error; // Ensure the error is thrown so it can be caught by the caller
+    handleError(error);
   }
 };
 
 export const fetchWithoutResponse = async (resource, options) => {
   try {
     const response = await fetch(`${API_URL}/${resource}`, options);
-    return checkError(response);
+    await checkErrorJson(response); // Check for errors but don't return the response
+    return true; // Or any other indicator of success
   } catch (error) {
-    catchError(error);
-    throw error; // Ensure the error is thrown so it can be caught by the caller
+    handleError(error);
   }
 };

--- a/data/fetcher.js
+++ b/data/fetcher.js
@@ -1,34 +1,39 @@
-const API_URL = 'http://localhost:8000'
+const API_URL = 'http://localhost:8000';
 
-const checkError = (res) => {
-  if (!res.ok) {
-    throw Error(res.status);
+const checkErrorJson = async (response) => {
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.message || 'Something went wrong');
   }
-  return res
-}
-
-const checkErrorJson = (res) => {
-  if (!res.ok) {
-    throw Error(res.status);
-  } else {
-    return res.json()
-  }
-}
-
+  return response.json(); // Ensure to return the parsed JSON
+};
 
 const catchError = (err) => {
   if (err.message === '401') {
-    window.location.href = "/login"
-  }
-  if (err.message === '404') {
+    window.location.href = "/login";
+  } else if (err.message === '404') {
     throw Error(err.message);
+  } else {
+    throw err; // Re-throw other errors so they can be handled by the caller
   }
-}
+};
 
-export const fetchWithResponse = (resource, options) => fetch(`${API_URL}/${resource}`, options)
-  .then(checkErrorJson)
-  .catch(catchError)
+export const fetchWithResponse = async (resource, options) => {
+  try {
+    const response = await fetch(`${API_URL}/${resource}`, options);
+    return await checkErrorJson(response);
+  } catch (error) {
+    catchError(error);
+    throw error; // Ensure the error is thrown so it can be caught by the caller
+  }
+};
 
-export const fetchWithoutResponse = (resource, options) => fetch(`${API_URL}/${resource}`, options)
-  .then(checkError)
-  .catch(catchError)
+export const fetchWithoutResponse = async (resource, options) => {
+  try {
+    const response = await fetch(`${API_URL}/${resource}`, options);
+    return checkError(response);
+  } catch (error) {
+    catchError(error);
+    throw error; // Ensure the error is thrown so it can be caught by the caller
+  }
+};

--- a/pages/register.js
+++ b/pages/register.js
@@ -18,9 +18,9 @@ export default function Register() {
   const [phoneNumber, setPhoneNumber] = useState('')
   const router = useRouter()
 
-  const submit = (e) => {
-    e.preventDefault()
-   
+  const submit = async (e) => {
+    e.preventDefault();
+  
     const user = {
       username,
       password,
@@ -29,16 +29,20 @@ export default function Register() {
       address,
       email,
       phone_number: phoneNumber,
-    }
-
-    register(user).then((res) => {
-     
+    };
+  
+    try {
+      const res = await register(user);
       if (res.token) {
-        setToken(res.token)
-        router.push('/')
+        setToken(res.token);
+        router.push('/');
       }
-    })
-  }
+    } catch (error) {
+     alert(error.message || 'Something went wrong');
+      }
+    }
+  ;
+  
 //Input vs. input? dig in here
   return (
     <div className="columns is-centered">


### PR DESCRIPTION
Ticket ##

https://github.com/day-cohort-70/Bangazon-API-team-3/issues/52

What Changed ##

Added check in register.py to see if a User with the same username or email address, or a Customer object with the same phone_number already exists before registering new account, to ensure no duplicate users/customer objects are created.

updated fetcher to handle based on err.status and not err.message.

How to Test ##

pull down both the API, and Client pull requests. try registering an account with a matching email, username, and phone_number as a user already in your database. verify the correct error message is shown in an alert.