### PR TITLE
Bugfix/cannot add items to cart

### DIFF
--- a/components/order/detail.js
+++ b/components/order/detail.js
@@ -1,5 +1,4 @@
 import Table from "../table"
-import 'bulma/css/bulma.min.css'
 
 
 export default function CartDetail({ cart, updateProductQuantity }) {

--- a/components/order/detail.js
+++ b/components/order/detail.js
@@ -1,22 +1,40 @@
 import Table from "../table"
+import 'bulma/css/bulma.min.css'
 
-export default function CartDetail({ cart, removeProduct }) {
-  const headers = ['Product', 'Price', '']
-  const footers = ['Total', cart.total, '']
+
+export default function CartDetail({ cart, updateProductQuantity }) {
+  const headers = ['Product', 'Description', 'Price', 'Quantity', '']
+  const footers = ['Total', '', cart.total, '', '']
 
   return (
     <Table headers={headers} footers={footers}>
       {
-        cart.products?.map(product => {
+        cart.line_items?.map(item => {
+          const { product, cart_quantity } = item;
           return (
-            <tr key={product.id}>
+            <tr key={item.id}>
               <td>{product.name}</td>
+              <td>{product.description}</td>
               <td>{product.price}</td>
               <td>
-                <span className="icon is-clickable" onClick={() => removeProduct(product.id)}>
-                  <i className="fas fa-trash"></i>
-                </span>
+                <div className="quantity-control">
+                  <button 
+                    className="button is-small is-danger mx-2" 
+                    onClick={() => updateProductQuantity(item.id, cart_quantity - 1)} 
+                    disabled={cart_quantity <= 1}
+                  >
+                    -
+                  </button>
+                  <span className="mx-2">{cart_quantity}</span>
+                  <button 
+                    className="button is-small is-success mx-2" 
+                    onClick={() => updateProductQuantity(item.id, cart_quantity + 1)}
+                  >
+                    +
+                  </button>
+                </div>
               </td>
+              <td></td>
             </tr>
           )
         })

--- a/data/orders.js
+++ b/data/orders.js
@@ -1,7 +1,7 @@
 import { fetchWithResponse } from './fetcher'
 
 export function getCart() {
-  return fetchWithResponse('cårt', {
+  return fetchWithResponse('cart', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`
     }

--- a/data/orders.js
+++ b/data/orders.js
@@ -1,7 +1,7 @@
 import { fetchWithResponse } from './fetcher'
 
 export function getCart() {
-  return fetchWithResponse('cart', {
+  return fetchWithResponse('profile/cart', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`
     }
@@ -24,5 +24,16 @@ export function completeCurrentOrder(orderId, paymentTypeId) {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({paymentTypeId})
+  })
+}
+
+export function updateProductQuantityInCart(productId, newQuantity) {
+  return fetchWithResponse('profile/cart', {
+    method: 'PUT',
+    headers: {
+      Authorization: `Token ${localStorage.getItem('token')}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ id: productId, cart_quantity: newQuantity })
   })
 }

--- a/data/products.js
+++ b/data/products.js
@@ -31,11 +31,15 @@ export function getProductById(id) {
 }
 
 export function addProductToOrder(id) {
-  return fetchWithResponse(`products/${id}/add_to_order`, {
+  return fetchWithResponse('profile/cart', {
     method: 'POST',
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`
-    }
+      Authorization: `Token ${localStorage.getItem('token')}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      product_id: id
+    })
   })
 }
 

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -5,7 +5,7 @@ import Layout from '../components/layout'
 import Navbar from '../components/navbar'
 import CartDetail from '../components/order/detail'
 import CompleteFormModal from '../components/order/form-modal'
-import { completeCurrentOrder, getCart } from '../data/orders'
+import { completeCurrentOrder, getCart, updateProductQuantityInCart } from '../data/orders'
 import { getPaymentTypes } from '../data/payment-types'
 import { removeProductFromOrder } from '../data/products'
 
@@ -40,6 +40,20 @@ export default function Cart() {
     removeProductFromOrder(productId).then(refresh)
   }
 
+  const updateProductQuantity = (productId, newQuantity) => {
+    updateProductQuantityInCart(productId, newQuantity).then(() => {
+      setCart(prevCart => {
+        const updatedLineItems = prevCart.line_items.map(item => {
+          if (item.id === productId) {
+            return { ...item, cart_quantity: newQuantity }
+          }
+          return item
+        })
+        return { ...prevCart, line_items: updatedLineItems }
+      })
+    })
+  }
+
   return (
     <>
       <CompleteFormModal
@@ -49,7 +63,7 @@ export default function Cart() {
         completeOrder={completeOrder}
       />
       <CardLayout title="Your Current Order">
-        <CartDetail cart={cart} removeProduct={removeProduct} />
+        <CartDetail cart={cart} removeProduct={removeProduct} updateProductQuantity={updateProductQuantity}/>
         <>
           <a className="card-footer-item" onClick={() => setShowCompleteForm(true)}>Complete Order</a>
           <a className="card-footer-item">Delete Order</a>


### PR DESCRIPTION
Added the ability for customers to add products from the products page to their cart as well as the ability to increase or decrease the quantity of each product once in the cart.

## Changes
- In data/orders.js, added service function for updating the quantity of a product in a customers cart as well as changed url path for the getCart function
- In order/detail.js, added logic for mapping line items and displaying details for each as well as an increase and decrease quantity button for each line item
- In pages/cart.js, added function to update and manage state for line item quantity in the cart

## Issue ticket number
Ticket #43

## Testing
- [ ] Start API in debug mode
- [ ] Run `npm run dev` for the client
- [ ] Login or register an account
- [ ] Navigate to the products page and find a product you wish to add to your cart, then click the product to navigate to the product details page
- [ ] Click the "Add to cart" button
- [ ] Navigate to your cart
- [ ] Verify that you can increase and decrease the quantity of a product in your cart

